### PR TITLE
fix: settings update should notify active tabs (firefox)

### DIFF
--- a/src/modules/autoblocker.js
+++ b/src/modules/autoblocker.js
@@ -1,4 +1,4 @@
-import {alertCap, browserVariant, classFlag} from '../config';
+import {alertCap, browserVariant, classFlag, isFirefox} from '../config';
 import Storage from './storage';
 import TwitterApi from './twitterApi';
 import bs from './blockerState'; // most definitely
@@ -47,13 +47,22 @@ export default class AutoBlocker {
      * Add message listener to know when to reload settings.
      */
     static registerListener() {
-        window.chrome.runtime.onMessage.addListener(
-            (request) => {
+        if (isFirefox) {
+            browser.runtime.onMessage.addListener(request => {
                 if (request.updateSettings) {
                     AutoBlocker.loadSettings();
-                    return true;
                 }
             });
+            return Promise.resolve();
+        } else {
+            window.chrome.runtime.onMessage.addListener(
+                (request) => {
+                    if (request.updateSettings) {
+                        AutoBlocker.loadSettings();
+                        return true;
+                    }
+                });
+        }
     }
 
     /**

--- a/src/modules/tabs.js
+++ b/src/modules/tabs.js
@@ -1,6 +1,6 @@
 // noinspection JSUnresolvedVariable,JSCheckFunctionSignatures,JSUnresolvedFunction,JSIgnoredPromiseFromCall
 
-import {browserVariant} from "../config";
+import {browserVariant, isFirefox} from '../config';
 
 /**
  * @description
@@ -26,13 +26,24 @@ export default class Tabs {
      * subscribed tabs.
      */
     static notifyTabsOfUpdate() {
-        browserVariant().tabs.query({}, tabs => {
-            for (let i = 0; i < tabs.length; ++i) {
-                // send message to update
-                browserVariant().tabs.sendMessage(tabs[i].id,
-                    {updateSettings: true}
-                );
-            }
-        });
+        if (isFirefox) {
+            browserVariant().tabs.query(
+                {url: 'https://*.twitter.com/*'})
+                .then(tabs => {
+                    for (let tab of tabs) {
+                        browser.tabs.sendMessage(
+                            tab.id, {updateSettings: true})
+                            .then().catch();
+                    }
+                }).catch();
+        } else {
+            browserVariant().tabs.query({}, tabs => {
+                for (let i = 0; i < tabs.length; ++i) {
+                    browserVariant().tabs.sendMessage(tabs[i].id,
+                        {updateSettings: true}
+                    );
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
firefox uses promises so need to handle it differently from all other browsers. The send message also fails if no listener is registered so need more detailed tabs query.