### PR TITLE
Add text area for allowed words that override blocking, and the ability to mute instead of block.

### DIFF
--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -53,6 +53,15 @@
       }
     }
   },
+  "proceedToMute": {
+    "message": "DO YOU WANT TO MUTE $name$?️",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "this user"
+      }
+    }
+  },
   "share_and_rate": {
     "message": "Share or Rate: "
   },

--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -18,7 +18,7 @@
     "message": "Confirm before blocking"
   },
   "muteInstead": {
-    "message": "Mute instead of blocking"
+    "message": "Mute instead of block"
   },
   "saveChanges": {
     "message": "Save"

--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -11,8 +11,14 @@
   "blockedWords": {
     "message": "List all your trigger words (separate by comma):"
   },
+  "allowedWords": {
+    "message": "Do not flag when these are present (separate by comma):"
+  },
   "confirmBlock": {
     "message": "Confirm before blocking"
+  },
+  "muteInstead": {
+    "message": "Mute instead of blocking"
   },
   "saveChanges": {
     "message": "Save"

--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -12,7 +12,7 @@
     "message": "List all your trigger words (separate by comma):"
   },
   "allowedWords": {
-    "message": "Do not flag when these are present (separate by comma):"
+    "message": "Don't flag when these are present (separate by comma):"
   },
   "confirmBlock": {
     "message": "Confirm before blocking"

--- a/assets/locales/tr/messages.json
+++ b/assets/locales/tr/messages.json
@@ -11,6 +11,9 @@
   "blockedWords": {
     "message": "Tüm tetikleyici sözcüklerinizi listeleyin (virgülle ayırın):"
   },
+  "allowedWords": {
+    "message": "Bunlar varken işaretlemeyin (virgülle ayırın):"
+  },
   "confirmBlock": {
     "message": "Engellemeden önce onayla"
   },

--- a/assets/locales/tr/messages.json
+++ b/assets/locales/tr/messages.json
@@ -53,6 +53,15 @@
       }
     }
   },
+  "proceedToMute": {
+    "message": "$name$ KULLANICIYI SUSTURMAK İSTER MİSİNİZ?️",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "this user"
+      }
+    }
+  },
   "share_and_rate": {
     "message": "Paylaş veya Değerlendir: "
   },

--- a/assets/locales/tr/messages.json
+++ b/assets/locales/tr/messages.json
@@ -17,6 +17,9 @@
   "confirmBlock": {
     "message": "Engellemeden önce onayla"
   },
+  "muteInstead": {
+    "message": "Engellemek yerine sessize al"
+  },
   "saveChanges": {
     "message": "Kaydet"
   },

--- a/src/config.js
+++ b/src/config.js
@@ -43,7 +43,7 @@ export const defaultConfig = {
      * @constant
      * @type {string}
      */
-    allowWords: '',
+    allowWords: 'magazine',
     /**
      * mute instead of block
      * @constant

--- a/src/config.js
+++ b/src/config.js
@@ -38,11 +38,24 @@ export const defaultConfig = {
      */
     blockWords: 'catalyst,innovator,futurist,serial entrepreneur,midas list',
     /**
+     * Default list of keywords that will prevent blocking until user
+     * defines their own allow list.
+     * @constant
+     * @type {string}
+     */
+    allowWords: 'VoteBlue,vote blue',
+    /**
      * Ask user to manually confirm all blocks
      * @constant
      * @type {Boolean}
      */
     confirm: true,
+    /**
+     * mute instead of block
+     * @constant
+     * @type {Boolean}
+     */
+    mute: false,
     /**
      * Number of accounts blocked by this extension
      * @constant
@@ -98,8 +111,23 @@ export const requestConfigs = {
      *
      * @constant
      * @type {string}
+     *
+     * Example: POST https://api.twitter.com/1.1/blocks/create.json?screen_name=theSeanCook&skip_status=1
      */
     blockEndpoint: 'https://twitter.com/i/api/1.1/blocks/create.json',
+    /**
+     * API endpoint for muting a user
+     *
+     * @constant
+     * @type {string}
+     *
+     * CURRENTLY STILL BLOCKS REGARDLESS UNTIL FIND THE CORRECT ENDPOINT TO REPLACE IT HERE
+     *
+     * Example: POST https://api.twitter.com/1.1/mutes/users/create.json?screen_name=evilpiper
+     *
+     * This differs from blocks, in that it always returns a JSON array for status... no skip_status flag available for mutes
+     */
+    muteEndpoint: 'https://api.twitter.com/1.1/mutes/users/create.json',
     /**
      * Endpoint for checking current friendship status between self and some other user.
      * @param {string} handle - specify only 1 username
@@ -194,7 +222,7 @@ export const alertCap = 3;
  * @constant
  * @type {number}
  */
-export const maxLogSize = 100;
+export const maxLogSize = 1000;
 
 /**
  * URLs for rating extension, depends on the current browser.

--- a/src/config.js
+++ b/src/config.js
@@ -121,15 +121,11 @@ export const requestConfigs = {
      * @constant
      * @type {string}
      *
-     * CURRENTLY, BASICALLY A PLACEHOLDER, STILL BLOCKS UNTIL OTHER CODE CAN BE CHANGED TO HANDLE MUTING CORRECTLY
-     *
-     * Proper Endpoint with Example User: POST https://api.twitter.com/1.1/mutes/users/create.json?screen_name=evilpiper
-     *
      * This differs from blocks, in that it always returns a JSON array for status... no skip_status flag available for mutes
      *
      * ref: https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-create
      */
-    muteEndpoint: 'https://twitter.com/i/api/1.1/blocks/create.json',
+    muteEndpoint: 'https://api.twitter.com/1.1/mutes/users/create.json',
     /**
      * Endpoint for checking current friendship status between self and some other user.
      * @param {string} handle - specify only 1 username

--- a/src/config.js
+++ b/src/config.js
@@ -43,7 +43,7 @@ export const defaultConfig = {
      * @constant
      * @type {string}
      */
-    allowWords: 'VoteBlue,vote blue',
+    allowWords: 'VoteBlue',
     /**
      * Ask user to manually confirm all blocks
      * @constant

--- a/src/config.js
+++ b/src/config.js
@@ -121,7 +121,7 @@ export const requestConfigs = {
      * @constant
      * @type {string}
      *
-     * CURRENTLY STILL BLOCKS REGARDLESS UNTIL OTHER CODE CAN BE CHANGED TO HANDLE CHECKING THE RELATIONSHIP, ETC
+     * CURRENTLY, BASICALLY A PLACEHOLDER, STILL BLOCKS REGARDLESS UNTIL OTHER CODE CAN BE CHANGED TO HANDLE CHECKING THE RELATIONSHIP, ETC
      *
      * Proper Endpoint with Example User: POST https://api.twitter.com/1.1/mutes/users/create.json?screen_name=evilpiper
      *

--- a/src/config.js
+++ b/src/config.js
@@ -43,7 +43,7 @@ export const defaultConfig = {
      * @constant
      * @type {string}
      */
-    allowWords: 'VoteBlue',
+    allowWords: '',
     /**
      * mute instead of block
      * @constant

--- a/src/config.js
+++ b/src/config.js
@@ -217,14 +217,14 @@ export const classFlag = 'dbt___seen-it-b4';
  * @constant
  * @type {number}
  */
-export const alertCap = 5;
+export const alertCap = 3;
 
 /**
  * Size of block log: maximum number of entries to log
  * @constant
  * @type {number}
  */
-export const maxLogSize = 500;
+export const maxLogSize = 100;
 
 /**
  * URLs for rating extension, depends on the current browser.

--- a/src/config.js
+++ b/src/config.js
@@ -217,14 +217,14 @@ export const classFlag = 'dbt___seen-it-b4';
  * @constant
  * @type {number}
  */
-export const alertCap = 3;
+export const alertCap = 5;
 
 /**
  * Size of block log: maximum number of entries to log
  * @constant
  * @type {number}
  */
-export const maxLogSize = 1000;
+export const maxLogSize = 500;
 
 /**
  * URLs for rating extension, depends on the current browser.

--- a/src/config.js
+++ b/src/config.js
@@ -45,19 +45,19 @@ export const defaultConfig = {
      */
     allowWords: 'VoteBlue',
     /**
-     * Ask user to manually confirm all blocks
-     * @constant
-     * @type {Boolean}
-     */
-    confirm: true,
-    /**
      * mute instead of block
      * @constant
      * @type {Boolean}
      */
     mute: false,
     /**
-     * Number of accounts blocked by this extension
+     * Ask user to manually confirm all blocks or mutes
+     * @constant
+     * @type {Boolean}
+     */
+    confirm: true,
+    /**
+     * Number of accounts blocked or muted by this extension
      * @constant
      * @type {number}
      */

--- a/src/config.js
+++ b/src/config.js
@@ -126,6 +126,8 @@ export const requestConfigs = {
      * Example: POST https://api.twitter.com/1.1/mutes/users/create.json?screen_name=evilpiper
      *
      * This differs from blocks, in that it always returns a JSON array for status... no skip_status flag available for mutes
+     *
+     * ref: https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-create
      */
     muteEndpoint: 'https://api.twitter.com/1.1/mutes/users/create.json',
     /**

--- a/src/config.js
+++ b/src/config.js
@@ -121,7 +121,7 @@ export const requestConfigs = {
      * @constant
      * @type {string}
      *
-     * CURRENTLY, BASICALLY A PLACEHOLDER, STILL BLOCKS REGARDLESS UNTIL OTHER CODE CAN BE CHANGED TO HANDLE CHECKING THE RELATIONSHIP, ETC
+     * CURRENTLY, BASICALLY A PLACEHOLDER, STILL BLOCKS UNTIL OTHER CODE CAN BE CHANGED TO HANDLE MUTING CORRECTLY
      *
      * Proper Endpoint with Example User: POST https://api.twitter.com/1.1/mutes/users/create.json?screen_name=evilpiper
      *

--- a/src/config.js
+++ b/src/config.js
@@ -121,15 +121,15 @@ export const requestConfigs = {
      * @constant
      * @type {string}
      *
-     * CURRENTLY STILL BLOCKS REGARDLESS UNTIL FIND THE CORRECT ENDPOINT TO REPLACE IT HERE
+     * CURRENTLY STILL BLOCKS REGARDLESS UNTIL OTHER CODE CAN BE CHANGED TO HANDLE CHECKING THE RELATIONSHIP, ETC
      *
-     * Example: POST https://api.twitter.com/1.1/mutes/users/create.json?screen_name=evilpiper
+     * Proper Endpoint with Example User: POST https://api.twitter.com/1.1/mutes/users/create.json?screen_name=evilpiper
      *
      * This differs from blocks, in that it always returns a JSON array for status... no skip_status flag available for mutes
      *
      * ref: https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-create
      */
-    muteEndpoint: 'https://api.twitter.com/1.1/mutes/users/create.json',
+    muteEndpoint: 'https://twitter.com/i/api/1.1/blocks/create.json',
     /**
      * Endpoint for checking current friendship status between self and some other user.
      * @param {string} handle - specify only 1 username

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,7 +28,8 @@
         "https://*.x.com/*"
       ],
       "exclude_globs": [
-        "https://twitter.com/settings/blocked/*"
+        "https://twitter.com/settings/blocked/*",
+        "https://twitter.com/settings/muted/*"
       ],
       "js": [
         "content.js"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://*.twitter.com/*"
+        "https://*.twitter.com/*",
+        "https://*.x.com/*"
       ],
       "exclude_globs": [
         "https://twitter.com/settings/blocked/*"

--- a/src/modules/autoblocker.js
+++ b/src/modules/autoblocker.js
@@ -74,6 +74,7 @@ export default class AutoBlocker {
     static loadSettings(callback) {
         Storage.getSettings(settings => {
             bs.keyList = settings[Storage.keys.blockWords];
+            bs.keyAllowList = settings[Storage.keys.allowWords];
             bs.confirmBlocks = settings[Storage.keys.confirm];
             bs.whiteList.whiteList = settings[Storage.keys.whiteList];
             if (callback) callback();
@@ -255,7 +256,8 @@ export default class AutoBlocker {
     static isBlockMatch(user) {
         return user.id &&
             !bs.whiteList.contains(user.id) &&
-            AutoBlocker.checkWords(bs.keyList, user);
+            AutoBlocker.checkWords(bs.keyList, user) &&
+            !AutoBlocker.checkWords(bs.keyAllowList, user);
     }
 
     /**

--- a/src/modules/autoblocker.js
+++ b/src/modules/autoblocker.js
@@ -370,11 +370,20 @@ export default class AutoBlocker {
             }
             // auto-block or user clicked OK to block
             else {
-                // ADD CODE HERE TO MUTE INSTEAD OF BLOCK IF THAT OPTION IS SELECTED... NEED TO ALSO ADD A METHOD TO TWITTER API
-                TwitterApi.doTheBlock(id,
-                    bs.tokens.bearerToken,
-                    bs.tokens.csrfToken,
-                    user);
+                // mute selected
+                if (bs.confirmMute){
+                    TwitterApi.doTheMute(id,
+                        bs.tokens.bearerToken,
+                        bs.tokens.csrfToken,
+                        user);
+                }
+                // mute not selected, proceed with a block
+                else {
+                    TwitterApi.doTheBlock(id,
+                        bs.tokens.bearerToken,
+                        bs.tokens.csrfToken,
+                        user);
+                }
             }
             // add some latency
             return window.setTimeout(resolve, 500);

--- a/src/modules/autoblocker.js
+++ b/src/modules/autoblocker.js
@@ -76,6 +76,7 @@ export default class AutoBlocker {
             bs.keyList = settings[Storage.keys.blockWords];
             bs.keyAllowList = settings[Storage.keys.allowWords];
             bs.confirmBlocks = settings[Storage.keys.confirm];
+            bs.confirmMute = settings[Storage.keys.mute];
             bs.whiteList.whiteList = settings[Storage.keys.whiteList];
             if (callback) callback();
         });
@@ -369,6 +370,7 @@ export default class AutoBlocker {
             }
             // auto-block or user clicked OK to block
             else {
+                // ADD CODE TO MUTE INSTEAD HERE IF THAT OPTION IS SELECTED... NEED TO ADD TO TWITTER API
                 TwitterApi.doTheBlock(id,
                     bs.tokens.bearerToken,
                     bs.tokens.csrfToken,

--- a/src/modules/autoblocker.js
+++ b/src/modules/autoblocker.js
@@ -426,7 +426,7 @@ export default class AutoBlocker {
                 !window.confirm(AutoBlocker.buildAlert(bio, name))) {
                 bs.whiteList.add(id, handle);
             }
-            // auto-block or user clicked OK to block
+            // auto-mute or user clicked OK to mute
             else {
                 TwitterApi.doTheMute(id,
                     bs.tokens.bearerToken,

--- a/src/modules/autoblocker.js
+++ b/src/modules/autoblocker.js
@@ -370,7 +370,7 @@ export default class AutoBlocker {
             }
             // auto-block or user clicked OK to block
             else {
-                // ADD CODE TO MUTE INSTEAD HERE IF THAT OPTION IS SELECTED... NEED TO ADD TO TWITTER API
+                // ADD CODE HERE TO MUTE INSTEAD OF BLOCK IF THAT OPTION IS SELECTED... NEED TO ALSO ADD A METHOD TO TWITTER API
                 TwitterApi.doTheBlock(id,
                     bs.tokens.bearerToken,
                     bs.tokens.csrfToken,

--- a/src/modules/autoblocker.js
+++ b/src/modules/autoblocker.js
@@ -349,7 +349,7 @@ export default class AutoBlocker {
                     if (isMuting) {
                         AutoBlocker.sequentiallyMute(users);
                     } else {
-                        AutoBlocker.executeBlock(first)
+                        AutoBlocker.executeMute(first)
                             .then(_ => AutoBlocker.sequentiallyMute(users))
                             .catch();
                     }
@@ -397,23 +397,46 @@ export default class AutoBlocker {
             }
             // auto-block or user clicked OK to block
             else {
-                // mute selected
-                if (bs.confirmMute){
-                    TwitterApi.doTheMute(id,
-                        bs.tokens.bearerToken,
-                        bs.tokens.csrfToken,
-                        user);
-                }
-                // mute not selected, proceed with a block
-                else {
-                    TwitterApi.doTheBlock(id,
-                        bs.tokens.bearerToken,
-                        bs.tokens.csrfToken,
-                        user);
+                TwitterApi.doTheBlock(id,
+                    bs.tokens.bearerToken,
+                    bs.tokens.csrfToken,
+                    user);
+            }
+            // add some latency
+            return window.setTimeout(resolve, 500);
+        });
+    }
+
+    /**
+     * Mute a user
+     * @param {Object} user - twitter user object
+     * @param {string} user.bio - bio text
+     * @param {string} user.id - twitter id
+     * @param {string} user.handle - handle
+     * @param {string} user.name - display name
+     * @param {string} user.match - matched keyword
+     * @param {string} user.img - profile image
+     * @returns {Promise}
+     */
+    static executeMute(user) {
+        const {bio, id, handle, name} = user;
+        return new Promise((resolve) => {
+            // user picked cancel -> whitelist this handle
+            if (bs.confirmBlocks &&
+                !window.confirm(AutoBlocker.buildAlert(bio, name))) {
+                bs.whiteList.add(id, handle);
+            }
+            // auto-block or user clicked OK to block
+            else {
+                TwitterApi.doTheMute(id,
+                    bs.tokens.bearerToken,
+                    bs.tokens.csrfToken,
+                    user);
                 }
             }
             // add some latency
             return window.setTimeout(resolve, 500);
         });
     }
+
 }

--- a/src/modules/blockerState.js
+++ b/src/modules/blockerState.js
@@ -292,5 +292,17 @@ export default class BlockerState {
     static set confirmBlocks(value) {
         this._confirm = value;
     }
+
+    /**
+     * Get/set mute setting
+     * @returns {Boolean}
+     */
+    static get confirmMute() {
+        return this._mute;
+    }
+
+    static set confirmMute(value) {
+        this._mute = value;
+    }
 }
 

--- a/src/modules/blockerState.js
+++ b/src/modules/blockerState.js
@@ -270,6 +270,18 @@ export default class BlockerState {
     }
 
     /**
+     * Get/set the list of allowed words that prevent blocking
+     * @returns {string[]}
+     */
+    static get keyAllowList() {
+        return this._keyAllowList;
+    }
+
+    static set keyAllowList(value) {
+        this._keyAllowList = value;
+    }
+
+    /**
      * Get/set confirmation setting
      * @returns {Boolean}
      */

--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -148,6 +148,17 @@ export default class Storage {
     /**
      * @static
      * @description
+     * Update mute user preference
+     * @param {Boolean} value - set true to mute instead of block
+     * @param {function} done - callback
+     */
+    static setMuteSetting(value, done = undefined) {
+        Storage.save(Storage.keys.mute, !!value, done);
+    }
+
+    /**
+     * @static
+     * @description
      * Update the count of completed block requests
      */
     static incrementCount() {

--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -80,10 +80,11 @@ export default class Storage {
         const keys = Object.values(Storage.keys)
             .filter(val => val !== Storage.keys.log);
         Storage.get(keys, res => {
-            const {confirm: c, blockWords: bw, allowWords: aw, whiteList: wl} = Storage.keys;
+            const {confirm: c, mute: m, blockWords: bw, allowWords: aw, whiteList: wl} = Storage.keys;
             const result = {
                 ...defaultConfig, ...res,
                 [c]: res[c] === undefined ? defaultConfig.confirm : res[c],
+                [m]: res[m] === undefined ? defaultConfig.mute : res[m],
                 [bw]: Storage.parseKeywords(res),
                 [aw]: Storage.parseAllowedKeywords(res),
                 [wl]: res[wl] || {}

--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -21,6 +21,7 @@ export default class Storage {
     static get keys() {
         return {
             blockWords: 'blockWords',
+            allowWords: 'allowWords',
             confirm: 'confirm',
             count: 'count',
             whiteList: 'whiteList',
@@ -58,6 +59,19 @@ export default class Storage {
 
     /**
      * @static
+     * @private
+     * @description Convert allowed keywords string into an array
+     * @param input
+     * @returns {string[]}
+     */
+    static parseAllowedKeywords(input) {
+        return (input[Storage.keys.allowWords] ||
+            defaultConfig.allowWords)
+            .split(',');
+    }
+    
+    /**
+     * @static
      * @description Get all user settings (except log)
      * @param {function} callback
      */
@@ -65,11 +79,12 @@ export default class Storage {
         const keys = Object.values(Storage.keys)
             .filter(val => val !== Storage.keys.log);
         Storage.get(keys, res => {
-            const {confirm: c, blockWords: bw, whiteList: wl} = Storage.keys;
+            const {confirm: c, blockWords: bw, allowWords: aw, whiteList: wl} = Storage.keys;
             const result = {
                 ...defaultConfig, ...res,
                 [c]: res[c] === undefined ? defaultConfig.confirm : res[c],
                 [bw]: Storage.parseKeywords(res),
+                [aw]: Storage.parseAllowedKeywords(res),
                 [wl]: res[wl] || {}
             };
             callback(result);
@@ -102,7 +117,23 @@ export default class Storage {
             .trim()).filter(f => f.length).join(',');
         Storage.save(Storage.keys.blockWords, strList, done);
     }
-
+    
+    /**
+     * @static
+     * @description
+     * Update the list of allowed keywords; this function
+     * will sanitize and strip the input
+     *
+     * @param {string} words - list of words to block
+     * @param {function} done - callback
+     */
+    static setAllowedWords(words, done = undefined) {
+        const list = (words || '').toLowerCase().split(',');
+        const strList = list.map(w => (w || '')
+            .trim()).filter(f => f.length).join(',');
+        Storage.save(Storage.keys.allowWords, strList, done);
+    }
+    
     /**
      * @static
      * @description

--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -23,6 +23,7 @@ export default class Storage {
             blockWords: 'blockWords',
             allowWords: 'allowWords',
             confirm: 'confirm',
+            mute: 'mute',
             count: 'count',
             whiteList: 'whiteList',
             log: 'log'

--- a/src/modules/twitterApi.js
+++ b/src/modules/twitterApi.js
@@ -99,30 +99,6 @@ export default class TwitterApi {
     }
 
     /**
-     * Mute a specific user
-     * @param {string} id - user id str
-     * @param {string} bearer - authentication bearer token
-     * @param {string} csrf - csrf token
-     * @param {Object} user - log entry for blocked user
-     */
-    static doTheMute(id, bearer, csrf, user) {
-        const xhr = new XMLHttpRequest();
-        xhr.open('POST', requestConfigs.muteEndpoint, true);
-        xhr.setRequestHeader('content-type', 'application/x-www-form-urlencoded');
-        xhr.setRequestHeader('Authorization', bearer);
-        xhr.setRequestHeader('x-csrf-token', csrf);
-        xhr.setRequestHeader('x-twitter-active-user', 'yes');
-        xhr.setRequestHeader('x-twitter-auth-type', 'OAuth2Session');
-        xhr.onload = _ => {
-            if (xhr.status === 200) {
-                Storage.incrementCount();
-                Storage.addLog(user);
-            }
-        };
-        xhr.send('user_id=' + id);
-    }
-
-    /**
      * Check in real-time if user is already being blocked.
      *
      * @param {String} handle - screen name to check
@@ -146,6 +122,30 @@ export default class TwitterApi {
         };
         xhr.onerror = onError;
         xhr.send();
+    }
+
+    /**
+     * Mute a specific user
+     * @param {string} id - user id str
+     * @param {string} bearer - authentication bearer token
+     * @param {string} csrf - csrf token
+     * @param {Object} user - log entry for blocked user
+     */
+    static doTheMute(id, bearer, csrf, user) {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', requestConfigs.muteEndpoint, true);
+        xhr.setRequestHeader('content-type', 'application/x-www-form-urlencoded');
+        xhr.setRequestHeader('Authorization', bearer);
+        xhr.setRequestHeader('x-csrf-token', csrf);
+        xhr.setRequestHeader('x-twitter-active-user', 'yes');
+        xhr.setRequestHeader('x-twitter-auth-type', 'OAuth2Session');
+        xhr.onload = _ => {
+            if (xhr.status === 200) {
+                Storage.incrementCount();
+                Storage.addLog(user);
+            }
+        };
+        xhr.send('user_id=' + id);
     }
 
     /**

--- a/src/modules/twitterApi.js
+++ b/src/modules/twitterApi.js
@@ -147,4 +147,30 @@ export default class TwitterApi {
         xhr.onerror = onError;
         xhr.send();
     }
+
+    /**
+     * Check in real-time if user is already being muted.
+     *
+     * @param {String} handle - screen name to check
+     * @param {string} bearer - authentication Bearer token
+     * @param {string} csrf - csrf token
+     * @param {function} callback
+     * @returns {boolean} True if already muting and False otherwise
+     */
+    static isMuting(handle, bearer, csrf, callback) {
+        const xhr = new XMLHttpRequest();
+        const onError = () => callback(false);
+        xhr.open('GET', requestConfigs.friendshipEndpoint(handle), true);
+        xhr.setRequestHeader('Authorization', bearer);
+        xhr.setRequestHeader('x-csrf-token', csrf);
+        xhr.onload = _ => {
+            if (xhr.readyState === 4) {
+                TwitterApi.parseResponse(xhr.response,
+                    resp => resp.data.user.legacy.muting,
+                    callback, onError);
+            }
+        };
+        xhr.onerror = onError;
+        xhr.send();
+    }
 }

--- a/src/modules/twitterApi.js
+++ b/src/modules/twitterApi.js
@@ -99,6 +99,30 @@ export default class TwitterApi {
     }
 
     /**
+     * Mute a specific user
+     * @param {string} id - user id str
+     * @param {string} bearer - authentication bearer token
+     * @param {string} csrf - csrf token
+     * @param {Object} user - log entry for blocked user
+     */
+    static doTheMute(id, bearer, csrf, user) {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', requestConfigs.muteEndpoint, true);
+        xhr.setRequestHeader('content-type', 'application/x-www-form-urlencoded');
+        xhr.setRequestHeader('Authorization', bearer);
+        xhr.setRequestHeader('x-csrf-token', csrf);
+        xhr.setRequestHeader('x-twitter-active-user', 'yes');
+        xhr.setRequestHeader('x-twitter-auth-type', 'OAuth2Session');
+        xhr.onload = _ => {
+            if (xhr.status === 200) {
+                Storage.incrementCount();
+                Storage.addLog(user);
+            }
+        };
+        xhr.send('user_id=' + id);
+    }
+
+    /**
      * Check in real-time if user is already being blocked.
      *
      * @param {String} handle - screen name to check

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -40,7 +40,7 @@
         </label>
         <label id="confirm-label">&nbsp;</label>
     </div>
-    <div class="block checkbox">
+    <div class="block checkbox" style="display:none">
         <label class="switch">
             <input type="checkbox" id="mute" tabindex="-1">
             <span class="slider round" id="mute_slider" tabindex="0"></span>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -40,7 +40,7 @@
         </label>
         <label id="confirm-label">&nbsp;</label>
     </div>
-    <div class="block checkbox" style="display:none">
+    <div class="block checkbox">
         <label class="switch">
             <input type="checkbox" id="mute" tabindex="-1">
             <span class="slider round" id="mute_slider" tabindex="0"></span>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -40,6 +40,13 @@
         </label>
         <label id="confirm-label">&nbsp;</label>
     </div>
+    <div class="block checkbox">
+        <label class="switch">
+            <input type="checkbox" id="mute" tabindex="-1">
+            <span class="slider round" id="mute_slider" tabindex="0"></span>
+        </label>
+        <label id="mute-label">&nbsp;</label>
+    </div>
 
     <div class="buttons">
         <button id="save" tabindex="0"></button>

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -29,6 +29,10 @@
         <label for="block-words" id="block-label">&nbsp;</label>
         <textarea id="block-words"></textarea>
     </div>
+    <div class="block">
+        <label for="allowed-words" id="allowed-label">&nbsp;</label>
+        <textarea id="allowed-words"></textarea>
+    </div>
     <div class="block checkbox">
         <label class="switch">
             <input type="checkbox" id="confirm" tabindex="-1">

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -30,7 +30,7 @@
         <textarea id="block-words"></textarea>
     </div>
     <div class="block">
-        <label for="allow-words" id="allow-label">&nbsp;</label>
+        <label for="allow-words" id="allow-label">Don't flag users with these keywords:</label>
         <textarea id="allow-words"></textarea>
     </div>
     <div class="block checkbox">

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -30,7 +30,7 @@
         <textarea id="block-words"></textarea>
     </div>
     <div class="block">
-        <label for="allow-words" id="allow-label">Don't flag users with these keywords:</label>
+        <label for="allow-words" id="allow-label">&nbsp;</label>
         <textarea id="allow-words"></textarea>
     </div>
     <div class="block checkbox">

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -30,8 +30,8 @@
         <textarea id="block-words"></textarea>
     </div>
     <div class="block">
-        <label for="allowed-words" id="allowed-label">&nbsp;</label>
-        <textarea id="allowed-words"></textarea>
+        <label for="allow-words" id="allow-label">&nbsp;</label>
+        <textarea id="allow-words"></textarea>
     </div>
     <div class="block checkbox">
         <label class="switch">

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -21,6 +21,7 @@ export default class Index extends Page {
 
         // translate text elements
         Index.getElement('block-label').innerText = Index.translate('blockedWords');
+        Index.getElement('allow-label').innerText = Index.translate('allowedWords');
         Index.getElement('confirm-label').innerText = Index.translate('confirmBlock');
         Index.getElement('help').innerText = Index.translate('help');
         Index.getElement('log-link').innerText = Index.translate('log_link');
@@ -49,6 +50,14 @@ export default class Index extends Page {
      */
     static get blockInput() {
         return Index.getElement('block-words');
+    }
+
+    /**
+     * Get allow keywords input DOM element
+     * @returns {HTMLElement}
+     */
+    static get allowInput() {
+        return Index.getElement('allow-words');
     }
 
     /**

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -23,6 +23,7 @@ export default class Index extends Page {
         Index.getElement('block-label').innerText = Index.translate('blockedWords');
         Index.getElement('allow-label').innerText = Index.translate('allowedWords');
         Index.getElement('confirm-label').innerText = Index.translate('confirmBlock');
+        Index.getElement('mute-label').innerText = Index.translate('muteInstead');
         Index.getElement('help').innerText = Index.translate('help');
         Index.getElement('log-link').innerText = Index.translate('log_link');
         Index.resetButtonText();

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -31,6 +31,7 @@ export default class Index extends Page {
         // bind actions
         Index.saveButton.onclick = Index.saveButton.onkeypress = Index.saveSettings;
         Index.getElement('confirm_slider').onkeypress = Index.toggleConfirm;
+        Index.getElement('mute_slider').onkeypress = Index.toggleMute;
 
         // load user settings
         Index.loadSettings();
@@ -70,6 +71,14 @@ export default class Index extends Page {
     }
 
     /**
+     * Get "mute instead of block" checkbox DOM element
+     * @returns {HTMLElement}
+     */
+    static get muteInput() {
+        return Index.getElement('mute');
+    }
+    
+    /**
      * Check if user has just installed.
      * @returns {boolean}
      */
@@ -95,14 +104,28 @@ export default class Index extends Page {
     }
 
     /**
+     * Toggle checkbox on enter click
+     * @param e
+     */
+    static toggleMute(e) {
+        if (e && e.key === 'Enter') {
+            Index.muteInput.checked = !Index.muteInput.checked;
+        }
+    }
+    
+    /**
      * Update user preferences
      */
     static saveSettings() {
         Storage.setBlockedWords(Index.blockInput.value, () => {
-            Storage.setConfirmationSetting(Index.confirmInput.checked, () => {
-                Index.saveButton.innerText = Index.translate('saved');
-                Tabs.notifyTabsOfUpdate();
-                window.setTimeout(Index.resetButtonText, 1000);
+            Storage.setAllowedWords(Index.allowInput.value, () => {
+                Storage.setConfirmationSetting(Index.confirmInput.checked, () => {
+                    Storage.setMuteSetting(Index.muteInput.checked, () => {
+                        Index.saveButton.innerText = Index.translate('saved');
+                        Tabs.notifyTabsOfUpdate();
+                        window.setTimeout(Index.resetButtonText, 1000);
+                    });
+                });
             });
         });
     }
@@ -117,8 +140,12 @@ export default class Index extends Page {
             // set the inputs
             Index.blockInput.value =
                 (settings[Storage.keys.blockWords] || []).join(', ');
+            Index.allowInput.value =
+                (settings[Storage.keys.allowWords] || []).join(', ');
             Index.confirmInput.checked =
                 settings[Storage.keys.confirm];
+            Index.muteInput.checked =
+                settings[Storage.keys.mute];
 
             // if enough blocks -> reveal additional content
             if (count > 1 && !Index.isIntro) {


### PR DESCRIPTION
This is first and foremost a request to review this code, and possibly help test it, as I have never developed an extension before, and am having trouble with the testing setup. While I'm working out what I'm doing wrong with npm to test a build, I thought it's worth asking you to look this over and see what you think, as you may want to integrate it into the public extension once it's correct.

This (hopefully) adds a new field for words that will override flagging a user, as it's easy to sweep up innocents that have certain keywords in their profiles specifically because they advocate against those people, organizations, social issues, etc, and it's usually easy enough to provide a different overriding word that also shows up in their profile, indicating they are fine for you. Or a keyword will get flagged as a substring of something you don't want flagged ("MAGA" also sweeps up "Smithsonian Magazine"), and this would be an easier way to provide quick overrides ("magazine") for the average user rather than figuring out the complicated regex to filter terms that are fine.

Also added an option to mute instead of block, because many users prefer that as it silences and removes people from your view, without letting them know you blocked them if they happen to follow a link to your account. Which for some people results in more or different harassment as someone posts a screenshot and says "hey go say hi to this person who blocked me" to all their followers.

Most of the muting add-on was by just duplicating functions for blocking and substituting "mute" for "block" in the right places, simply to keep things simple without a lot of conditional statement everywhere. Other existing functions were modified to check the muting checkbox value before calling a mute or block function.

For Line 169 of TwitterAPI.js, I have no idea if the value I used of "resp => resp.data.user.legacy.muting," is even valid, as I cannot figure out where that data is coming from by the API reference. I'm hoping that "legacy" data also has "following" etc, and that using "muting" instead of "blocking" in your original function would succeed. But, again, still not able to test this thing yet.

English is my native language, and sometimes barely that, so please check the Turkish(?) local entries as I did them with Google Translate.
