### PR TITLE
2nd try: Add text area for allowed words that override blocking, and the ability to mute instead of block.

### DIFF
--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -11,8 +11,14 @@
   "blockedWords": {
     "message": "List all your trigger words (separate by comma):"
   },
+  "allowedWords": {
+    "message": "Don't flag when these are present (separate by comma):"
+  },
   "confirmBlock": {
     "message": "Confirm before blocking"
+  },
+  "muteInstead": {
+    "message": "Mute instead of block"
   },
   "saveChanges": {
     "message": "Save"
@@ -40,6 +46,15 @@
   },
   "proceedToBlock": {
     "message": "DO YOU WANT TO BLOCK $name$?️",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "this user"
+      }
+    }
+  },
+  "proceedToMute": {
+    "message": "DO YOU WANT TO MUTE $name$?️",
     "placeholders": {
       "name": {
         "content": "$1",

--- a/assets/locales/tr/messages.json
+++ b/assets/locales/tr/messages.json
@@ -11,8 +11,14 @@
   "blockedWords": {
     "message": "Tüm tetikleyici sözcüklerinizi listeleyin (virgülle ayırın):"
   },
+  "allowedWords": {
+    "message": "Bunlar varken işaretlemeyin (virgülle ayırın):"
+  },
   "confirmBlock": {
     "message": "Engellemeden önce onayla"
+  },
+  "muteInstead": {
+    "message": "Engellemek yerine sessize al"
   },
   "saveChanges": {
     "message": "Kaydet"
@@ -40,6 +46,15 @@
   },
   "proceedToBlock": {
     "message": "$name$ KULLANICISINI ENGELLEMEK İSTİYOR MUSUNUZ?️",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "this user"
+      }
+    }
+  },
+  "proceedToMute": {
+    "message": "$name$ KULLANICIYI SUSTURMAK İSTER MİSİNİZ?️",
     "placeholders": {
       "name": {
         "content": "$1",

--- a/src/config.js
+++ b/src/config.js
@@ -38,13 +38,26 @@ export const defaultConfig = {
      */
     blockWords: 'catalyst,innovator,futurist,serial entrepreneur,midas list',
     /**
-     * Ask user to manually confirm all blocks
+     * Default list of keywords that will prevent blocking until user
+     * defines their own allow list.
+     * @constant
+     * @type {string}
+     */
+    allowWords: 'magazine',
+    /**
+     * mute instead of block
+     * @constant
+     * @type {Boolean}
+     */
+    mute: false,
+    /**
+     * Ask user to manually confirm all blocks or mutes
      * @constant
      * @type {Boolean}
      */
     confirm: true,
     /**
-     * Number of accounts blocked by this extension
+     * Number of accounts blocked or muted by this extension
      * @constant
      * @type {number}
      */
@@ -98,8 +111,21 @@ export const requestConfigs = {
      *
      * @constant
      * @type {string}
+     *
+     * Example: POST https://api.twitter.com/1.1/blocks/create.json?screen_name=theSeanCook&skip_status=1
      */
     blockEndpoint: 'https://twitter.com/i/api/1.1/blocks/create.json',
+    /**
+     * API endpoint for muting a user
+     *
+     * @constant
+     * @type {string}
+     *
+     * This differs from blocks, in that it always returns a JSON array for status... no skip_status flag available for mutes
+     *
+     * ref: https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-create
+     */
+    muteEndpoint: 'https://api.twitter.com/1.1/mutes/users/create.json',
     /**
      * Endpoint for checking current friendship status between self and some other user.
      * @param {string} handle - specify only 1 username

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,10 +24,12 @@
   "content_scripts": [
     {
       "matches": [
-        "https://*.twitter.com/*"
+        "https://*.twitter.com/*",
+        "https://*.x.com/*"
       ],
       "exclude_globs": [
-        "https://twitter.com/settings/blocked/*"
+        "https://twitter.com/settings/blocked/*",
+        "https://twitter.com/settings/muted/*"
       ],
       "js": [
         "content.js"

--- a/src/modules/autoblocker.js
+++ b/src/modules/autoblocker.js
@@ -74,7 +74,9 @@ export default class AutoBlocker {
     static loadSettings(callback) {
         Storage.getSettings(settings => {
             bs.keyList = settings[Storage.keys.blockWords];
+            bs.keyAllowList = settings[Storage.keys.allowWords];
             bs.confirmBlocks = settings[Storage.keys.confirm];
+            bs.confirmMute = settings[Storage.keys.mute];
             bs.whiteList.whiteList = settings[Storage.keys.whiteList];
             if (callback) callback();
         });
@@ -240,8 +242,13 @@ export default class AutoBlocker {
         const blockable = users.filter(AutoBlocker.isBlockMatch);
         // remaining users after applying max alerts cap
         const limited = AutoBlocker.limitAlertCount(blockable);
-        // proceed to block
-        AutoBlocker.sequentiallyBlock(limited);
+        // proceed to block or mute
+        if (bs.confirmMute){
+            AutoBlocker.sequentiallyMute(limited);
+        }
+        else {
+            AutoBlocker.sequentiallyBlock(limited);
+        }
     }
 
     /**
@@ -255,7 +262,8 @@ export default class AutoBlocker {
     static isBlockMatch(user) {
         return user.id &&
             !bs.whiteList.contains(user.id) &&
-            AutoBlocker.checkWords(bs.keyList, user);
+            AutoBlocker.checkWords(bs.keyList, user) &&
+            !AutoBlocker.checkWords(bs.keyAllowList, user);
     }
 
     /**
@@ -328,6 +336,28 @@ export default class AutoBlocker {
     }
 
     /**
+     * Recursively mute a list of users
+     *
+     * @param {Object[]} users
+     */
+    static sequentiallyMute(users) {
+        if (users && users.length) {
+            const first = users.shift();
+            // filter out users that are already blocked
+            TwitterApi.isMuting(first.handle, bs.tokens.bearerToken,
+                bs.tokens.csrfToken, isMuting => {
+                    if (isMuting) {
+                        AutoBlocker.sequentiallyMute(users);
+                    } else {
+                        AutoBlocker.executeMute(first)
+                            .then(_ => AutoBlocker.sequentiallyMute(users))
+                            .catch();
+                    }
+                });
+        }
+    }
+
+    /**
      * Construct a window alert
      *
      * @param {string} bio - user's bio text
@@ -376,4 +406,37 @@ export default class AutoBlocker {
             return window.setTimeout(resolve, 500);
         });
     }
+
+    /**
+     * Mute a user
+     * @param {Object} user - twitter user object
+     * @param {string} user.bio - bio text
+     * @param {string} user.id - twitter id
+     * @param {string} user.handle - handle
+     * @param {string} user.name - display name
+     * @param {string} user.match - matched keyword
+     * @param {string} user.img - profile image
+     * @returns {Promise}
+     */
+    static executeMute(user) {
+        const {bio, id, handle, name} = user;
+        return new Promise((resolve) => {
+            // user picked cancel -> whitelist this handle
+            if (bs.confirmBlocks &&
+                !window.confirm(AutoBlocker.buildAlert(bio, name))) {
+                bs.whiteList.add(id, handle);
+            }
+            // auto-mute or user clicked OK to mute
+            else {
+                TwitterApi.doTheMute(id,
+                    bs.tokens.bearerToken,
+                    bs.tokens.csrfToken,
+                    user);
+                }
+            }
+            // add some latency
+            return window.setTimeout(resolve, 500);
+        });
+    }
+
 }

--- a/src/modules/blockerState.js
+++ b/src/modules/blockerState.js
@@ -270,6 +270,18 @@ export default class BlockerState {
     }
 
     /**
+     * Get/set the list of allowed words that prevent blocking
+     * @returns {string[]}
+     */
+    static get keyAllowList() {
+        return this._keyAllowList;
+    }
+
+    static set keyAllowList(value) {
+        this._keyAllowList = value;
+    }
+
+    /**
      * Get/set confirmation setting
      * @returns {Boolean}
      */
@@ -279,6 +291,18 @@ export default class BlockerState {
 
     static set confirmBlocks(value) {
         this._confirm = value;
+    }
+
+    /**
+     * Get/set mute setting
+     * @returns {Boolean}
+     */
+    static get confirmMute() {
+        return this._mute;
+    }
+
+    static set confirmMute(value) {
+        this._mute = value;
     }
 }
 

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -29,12 +29,23 @@
         <label for="block-words" id="block-label">&nbsp;</label>
         <textarea id="block-words"></textarea>
     </div>
+    <div class="block">
+        <label for="allow-words" id="allow-label">&nbsp;</label>
+        <textarea id="allow-words"></textarea>
+    </div>
     <div class="block checkbox">
         <label class="switch">
             <input type="checkbox" id="confirm" tabindex="-1">
             <span class="slider round" id="confirm_slider" tabindex="0"></span>
         </label>
         <label id="confirm-label">&nbsp;</label>
+    </div>
+    <div class="block checkbox">
+        <label class="switch">
+            <input type="checkbox" id="mute" tabindex="-1">
+            <span class="slider round" id="mute_slider" tabindex="0"></span>
+        </label>
+        <label id="mute-label">&nbsp;</label>
     </div>
 
     <div class="buttons">

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -21,7 +21,9 @@ export default class Index extends Page {
 
         // translate text elements
         Index.getElement('block-label').innerText = Index.translate('blockedWords');
+        Index.getElement('allow-label').innerText = Index.translate('allowedWords');
         Index.getElement('confirm-label').innerText = Index.translate('confirmBlock');
+        Index.getElement('mute-label').innerText = Index.translate('muteInstead');
         Index.getElement('help').innerText = Index.translate('help');
         Index.getElement('log-link').innerText = Index.translate('log_link');
         Index.resetButtonText();
@@ -29,6 +31,7 @@ export default class Index extends Page {
         // bind actions
         Index.saveButton.onclick = Index.saveButton.onkeypress = Index.saveSettings;
         Index.getElement('confirm_slider').onkeypress = Index.toggleConfirm;
+        Index.getElement('mute_slider').onkeypress = Index.toggleMute;
 
         // load user settings
         Index.loadSettings();
@@ -52,6 +55,14 @@ export default class Index extends Page {
     }
 
     /**
+     * Get allow keywords input DOM element
+     * @returns {HTMLElement}
+     */
+    static get allowInput() {
+        return Index.getElement('allow-words');
+    }
+
+    /**
      * Get "confirm blocks" checkbox DOM element
      * @returns {HTMLElement}
      */
@@ -59,6 +70,14 @@ export default class Index extends Page {
         return Index.getElement('confirm');
     }
 
+    /**
+     * Get "mute instead of block" checkbox DOM element
+     * @returns {HTMLElement}
+     */
+    static get muteInput() {
+        return Index.getElement('mute');
+    }
+    
     /**
      * Check if user has just installed.
      * @returns {boolean}
@@ -85,14 +104,28 @@ export default class Index extends Page {
     }
 
     /**
+     * Toggle checkbox on enter click
+     * @param e
+     */
+    static toggleMute(e) {
+        if (e && e.key === 'Enter') {
+            Index.muteInput.checked = !Index.muteInput.checked;
+        }
+    }
+    
+    /**
      * Update user preferences
      */
     static saveSettings() {
         Storage.setBlockedWords(Index.blockInput.value, () => {
-            Storage.setConfirmationSetting(Index.confirmInput.checked, () => {
-                Index.saveButton.innerText = Index.translate('saved');
-                Tabs.notifyTabsOfUpdate();
-                window.setTimeout(Index.resetButtonText, 1000);
+            Storage.setAllowedWords(Index.allowInput.value, () => {
+                Storage.setConfirmationSetting(Index.confirmInput.checked, () => {
+                    Storage.setMuteSetting(Index.muteInput.checked, () => {
+                        Index.saveButton.innerText = Index.translate('saved');
+                        Tabs.notifyTabsOfUpdate();
+                        window.setTimeout(Index.resetButtonText, 1000);
+                    });
+                });
             });
         });
     }
@@ -107,8 +140,12 @@ export default class Index extends Page {
             // set the inputs
             Index.blockInput.value =
                 (settings[Storage.keys.blockWords] || []).join(', ');
+            Index.allowInput.value =
+                (settings[Storage.keys.allowWords] || []).join(', ');
             Index.confirmInput.checked =
                 settings[Storage.keys.confirm];
+            Index.muteInput.checked =
+                settings[Storage.keys.mute];
 
             // if enough blocks -> reveal additional content
             if (count > 1 && !Index.isIntro) {


### PR DESCRIPTION
This is first and foremost a request to review this code, and possibly help test it, as I have never developed an extension before, and am having trouble with the testing setup. While I'm working out what I'm doing wrong with npm to test a build, I thought it's worth asking you to look this over and see what you think, as you may want to integrate it into the public extension once it's correct.

This (hopefully) adds a new field for words that will override flagging a user, as it's easy to sweep up innocents that have certain keywords in their profiles specifically because they advocate against those people, organizations, social issues, etc, and it's usually easy enough to provide a different overriding word that also shows up in their profile, indicating they are fine for you. Or a keyword will get flagged as a substring of something you don't want flagged, and this would be an easier way to provide quick overrides for the average user rather than figuring out the complicated regex to filter terms that are fine.

Also added an option to mute instead of block, because many users prefer that as it silences and removes people from your view, without letting them know you blocked them if they happen to follow a link to your account. Which for some people results in more or different harassment as someone posts a screenshot and says "hey go say hi to this person who blocked me" to all their followers.

Most of the muting add-on was by just duplicating functions for blocking and substituting "mute" for "block" in the right places, simply to keep things simple without a lot of conditional statement everywhere. Other existing functions were modified to check the muting checkbox value before calling a mute or block function.

For Line 169 of TwitterAPI.js, I have no idea if the value I used of "resp => resp.data.user.legacy.muting," is even valid, as I cannot figure out where that data is coming from by the API reference. I'm hoping that "legacy" data also has "following" etc, and that using "muting" instead of "blocking" in your original function would succeed. But, again, still not able to test this thing yet.

English is my native language, and sometimes barely that, so please check the Turkish(?) local entries as I did them with Google Translate.
