### PR TITLE
Fix broken firefox.json and chromium.json

### DIFF
--- a/.chromium.json
+++ b/.chromium.json
@@ -9,15 +9,15 @@
     },
     {
       "name": "options",
-      "src": "./src/options/index.js"
+      "src": "./src/options.js"
     },
     {
       "name": "help",
-      "src": "./src/options/help/help.js"
+      "src": "./src/help.js"
     },
     {
       "name": "log",
-      "src": "./src/options/log/log.js"
+      "src": "./src/log.js"
     },
     {
       "name": "background",

--- a/.firefox.json
+++ b/.firefox.json
@@ -10,15 +10,15 @@
     },
     {
       "name": "options",
-      "src": "./src/options/index.js"
+      "src": "./src/options.js"
     },
     {
       "name": "help",
-      "src": "./src/options/help/help.js"
+      "src": "./src/help.js"
     },
     {
       "name": "log",
-      "src": "./src/options/log/log.js"
+      "src": "./src/log.js"
     },
     {
       "name": "background",


### PR DESCRIPTION
Master source currently doesn't compile correctly, because apparently (as far as I can guess) when the help and log files were relocated into their own subfolders, and the containing folder was renamed from "pages" to "options", the paths in the firefox.json and chromium.json files were improperly changed to the further downstream files instead of the ones in the base /src folder that references them. So the index.html, options.js, log.js, and help.js files were compiling without the support files page.js, etc, resulting in completely broken GUI, non-functional pages.

This PR just corrects those paths in the firefox.json and chromium.json files, so the GUI now looks proper and is functional.